### PR TITLE
Add TypeScript as a dependency.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,9 @@ gulp.task("javascript", function () {
     debug: true
   });
   b.on("log", gutil.log); // output build logs to terminal
-  b.plugin("tsify");
+  b.plugin(tsify, {
+    typescript: require("typescript")
+  });
 
   return b.bundle()
     // log errors if they happen

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-util": "^3.0.6",
     "tsd": "^0.6.3",
     "tsify": "^0.11.2",
+    "typescript": "^1.5.0-beta",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },


### PR DESCRIPTION
I think we should explicitly set TypeScript as a dependency and not assume a global version is installed.
